### PR TITLE
add gitleaks config to ruleset

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -43,3 +43,61 @@ id = "employee-id-local-login"
 description = "Employee ID (A/a + 9 digits)"
 regex = '''\b[Aa]\d{9}\b'''
 tags = ["custom", "pii", "employee-id"]
+
+# Additional rules from https://github.com/shafnir/Gitleaks/tree/main
+
+[[rules]]
+id = "generic-password"
+description = "Generic password assignments (password, pass, passwd, passphrase)"
+regex = '''(?i)\b(pass(word|phrase)?|passwd)\b\s*[:=]\s*["']?[a-z0-9!@#$%^&*()_+={}\[\]:;<>,.?\/\\|~-]{6,}["']?'''
+secretGroup = 0
+tags = ["password"]
+
+[[rules]]
+id = "env-password"
+description = "Environment variable style secrets (UPPERCASE-like vars)"
+regex = '''\b([A-Z0-9_]+_?(PASS|PASSWORD|SECRET|TOKEN)[A-Z0-9_]*)\b\s*[:=]\s*["']?[A-Za-z0-9!@#$%^&*()_+={}\[\]:;<>,.?\/\\|~-]{6,}["']?'''
+secretGroup = 0
+tags = ["env", "password", "token"]
+
+[[rules]]
+id = "db-password"
+description = "Database-specific password or secret values"
+regex = '''(?i)\b(db[_\-]?(pass(word)?|passwd|secret))\b\s*[:=]\s*["']?[a-z0-9!@#$%^&*()_+={}\[\]:;<>,.?\/\\|~-]{6,}["']?'''
+secretGroup = 0
+tags = ["database", "password"]
+
+[[rules]]
+id = "generic-api-key"
+description = "Generic API key assignments (api_key, access_key, key)"
+regex = '''(?i)\b(api[_\-]?key|access[_\-]?key|key)\b\s*[:=]\s*["']?[a-zA-Z0-9_\-]{12,}["']?'''
+secretGroup = 0
+tags = ["apikey"]
+
+[[rules]]
+id = "generic-secret"
+description = "General-purpose secret or private key assignments"
+regex = '''(?i)\b(secret|sec[_\-]?key|client[_\-]?secret|private[_\-]?key)\b\s*[:=]\s*["']?[a-z0-9!@#$%^&*()_+={}\[\]:;<>,.?\/\\|~-]{8,}["']?'''
+secretGroup = 0
+tags = ["secret"]
+
+[[rules]]
+id = "generic-token"
+description = "Access/session/bearer tokens with long values"
+regex = '''(?i)\b(token|auth[_\-]?token|bearer[_\-]?token|session[_\-]?token|access[_\-]?token)\b\s*[:=]\s*["']?[a-z0-9\-_\.]{16,}["']?'''
+secretGroup = 0
+tags = ["token"]
+
+[[rules]]
+id = "jwt-token"
+description = "JWT token format (header.payload.signature)"
+regex = '''eyJ[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+'''
+secretGroup = 0
+tags = ["jwt", "token"]
+
+[[rules]]
+id = "generic-auth"
+description = "Generic credential assignments like auth, login, cred"
+regex = '''(?i)\b(auth|login|cred|credentials)\b\s*[:=]\s*["']?[a-zA-Z0-9!@#$%^&*()_+]{6,}["']?'''
+secretGroup = 0
+tags = ["auth", "credentials"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,45 @@
+title = "TSI hooked gitleaks ruleset"
+
+# TODO: needs to be vetted
+
+redact = true
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+  description = "Global allowlist for known safe files/paths/patterns"
+  # Ignore typical test fixtures, examples, and lockfiles that often look secret-y
+  files = [
+    '''(?i)^(|.*/)(README|CHANGELOG|LICENSE)(\.md)?$''',
+    '''(?i)^.*/?(tests?|fixtures?|samples?|examples?)/.*$''',
+    '''(?i)^package-lock\.json$''',
+    '''(?i)^yarn\.lock$''',
+    '''(?i)^\.git/yarn\.lock$''',
+    '''(?i)^\.git[\\/]+hooks[\\/]+.*$'''
+  ]
+
+  paths = [
+    '''(?i)^.*/?\.git/.*$''',
+    '''(?i)^.*/?\.svn/.*$''',
+    '''(?i)^.*/?\.hg/.*$''',
+    '''(?i)^.*/?node_modules/.*$''',
+    '''(?i)^.*/?\.idea/.*$''',
+    '''(?i)^.*/?\.vscode/.*$''',
+    '''(?i)^.*/?__pycache__/.*$''',
+    '''(?i)^.*/?\$tf\.state(\.backup)?$''',
+    '''(?i)^.*/?\.terraform/.*$'''
+  ]
+
+  # Ignore obvious false-positive patterns (UUIDs, hex blobs used in tests, etc.)
+  regexes = [
+    '''(?i)example(_|-)secret''',
+    '''(?i)dummy(_|-)token''',
+    '''\b[0-9a-f]{32}\b''',
+  ]
+
+[[rules]]
+id = "employee-id-local-login"
+description = "Employee ID (A/a + 9 digits)"
+regex = '''\b[Aa]\d{9}\b'''
+tags = ["custom", "pii", "employee-id"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,12 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: gitleaks-staged
+        name: Gitleaks (staged changes)
+        language: system
+        entry: gitleaks git -v --redact --pre-commit --staged .
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit, manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/conmob-devsecops/pre-commit-hooks/
-    rev: v1.0.0
+    rev: v1.1.0
     hooks:
       - id: check-git-user-email
         args:
@@ -11,6 +11,8 @@ repos:
             "external.telekom.de",
             "external.t-systems.com",
           ]
+      - id: check-prohibited-filenames
+        args: [ "--prohibited-filenames", "node_modules",  ".DS_Store" ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository containts configurations to be used with the [hooked](https://gi
 Point `hooked` to this repository, for example:
 
 ```bash
-hooked install --rules git@github.com:conmob-devsecops/hooked-ruleset-tsi.git
+hooked install git@github.com:conmob-devsecops/hooked-ruleset-tsi.git
 ```
 
 ## Hooks
@@ -15,6 +15,10 @@ hooked install --rules git@github.com:conmob-devsecops/hooked-ruleset-tsi.git
 ### check-git-user-email
 
 Only allow commits, if git user email is using a domain included in the allowed set of domains.
+
+### check-prohibited-filenames
+
+Disallow certain filenames, similar to .gitignore patterns.
 
 ### trailing-whitespace
 
@@ -26,3 +30,19 @@ Runs local gitleaks scan on staged changes only, see [gitleaks](https://github.c
 and how to install. Pre-build binaries are available on the [releases page](https://github.com/gitleaks/gitleaks/releases).
 
 **Note:** You need to have `gitleaks` installed and available in your PATH for this hook to work.
+
+#### Gitleaks configuration
+
+The gitleaks configuration file `.gitleaks.toml` is included in this repository. It extends the default gitleaks ruleset
+with some additional rules and exclusions.
+
+Excluded paths:
+
+- /docs/
+- /contrib/
+- /examples/
+
+Here you can store documentation, example code and community contributions without risking false positives from
+gitleaks scans.
+
+Also excluded are auto-generated files of commonly used package managers for various programming languages.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ Only allow commits, if git user email is using a domain included in the allowed 
 ### trailing-whitespace
 
 Trims trailing whitespace, see [trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#trailing-whitespace)
+
+### gitleaks-staged
+
+Runs local gitleaks scan on staged changes only, see [gitleaks](https://github.com/gitleaks/gitleaks) for more information
+and how to install. Pre-build binaries are available on the [releases page](https://github.com/gitleaks/gitleaks/releases).
+
+**Note:** You need to have `gitleaks` installed and available in your PATH for this hook to work.


### PR DESCRIPTION
A basic gitleaks config, with custom TSI rules to exclude certain directories from scanning.

Also scans for employee ids.