### PR TITLE
added agents configs and hook dirs to the prohibited files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,22 @@ repos:
           - .pypirc
           - .npmrc
           - .pgpass
+          - .claude/settings.json
+          - .claude/settings.local.json
+          - .claude/hooks
+          - .cursor/mcp.json
+          - .cursor/tasks.json
+          - .gemini/settings.json
+          - .vscode/tasks.json
+          - .codex/config.json
+          - .codex/hooks
+          - .github/copilot/config.json
+          - .github/copilot/hooks
+          - .copilot/hooks
+          - .copilot/settings.json
+          - opencode.json
+          - tui.json
+          - .opencode/plugins
   - repo: local
     hooks:
       - id: gitleaks-staged

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ without risking false positives from gitleaks scans.
 
 - Common files in software development, that contain secrets (e.g., `.env`, `.env.local`)
 - Files, that should never be part of a commit (e.g., `.DS_Store`, `Thumbs.db`)
+- Files, that configure AI agents and their hooks (e.g., Claude, Codex, Copilot,
+  Opencode)
 - Employee ID (so called "A-Kennung")
 - Commit author email addresses other than `t-systems.com` or `telekom.de`
   (including externals)


### PR DESCRIPTION
Prevent unattended changes to AI agent configs through worms. Changes to these files need to be done with `hooked` disabled.